### PR TITLE
MAINT: increase right boarder slightly to avoid cutting off tick label

### DIFF
--- a/SNIDNewZTF/NewGraph.ipynb
+++ b/SNIDNewZTF/NewGraph.ipynb
@@ -143,7 +143,7 @@
     "    \n",
     "    \n",
     "    ax.legend(fancybox=True)\n",
-    "    fig.subplots_adjust(left=0.055,right=0.99,top=0.925,bottom=0.145)\n",
+    "    fig.subplots_adjust(left=0.055,right=0.975,top=0.925,bottom=0.145)\n",
     "    fig.savefig(output + 'snidfits_emclip_' + fname + \"_\" + str(best_num) + '.png', dpi = 600)\n",
     "    plt.close(fig)\n"
    ]


### PR DESCRIPTION
For some spectra the rightmost tick label gets cut off with the current spacing. It we add just a little more whitespace this should no longer be an issue.